### PR TITLE
feat: implement source lock

### DIFF
--- a/src/lookup/edit2web-onedrive.js
+++ b/src/lookup/edit2web-onedrive.js
@@ -55,7 +55,9 @@ async function lookup(context, info, opts) {
   const { editUrl, contentBusId, source } = opts;
   let uri = new URL(editUrl);
 
-  const drive = await context.getOneDriveClient(info.org, contentBusId);
+  const drive = await context.getOneDriveClient(info.org, info.site, {
+    contentBusId,
+  });
   drive.auth.tenant = source.tenantId;
 
   // if uri is sharelink, resolve it first

--- a/src/lookup/web2edit-onedrive.js
+++ b/src/lookup/web2edit-onedrive.js
@@ -31,9 +31,13 @@ async function lookup(context, info, { contentBusId, source }) {
     org, site, resourcePath, route, webPath,
   } = info;
 
-  const drive = await context.getOneDriveClient(org, contentBusId, source.tenantId, {
-    project: `${org}/${site}`,
-    operation: `${route} ${resourcePath}`,
+  const drive = await context.getOneDriveClient(org, site, {
+    contentBusId,
+    tenant: source.tenantId,
+    logFields: {
+      project: `${org}/${site}`,
+      operation: `${route} ${resourcePath}`,
+    },
   });
   const {
     location,

--- a/src/support/source-lock.js
+++ b/src/support/source-lock.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { StatusCodeError } from './StatusCodeError.js';
+
+const sourceLock = {
+  /**
+   * Evaluates the source lock configuration and checks if the given site is allowed to use the
+   * respective mountpoint.
+   *
+   * @param {import('./support/AdminContext').AdminContext} context context
+   * @param {string} org org
+   * @param {string} site site
+   * @param {URL} url the source url
+   * @returns {Promise<{reason: string, allowed: boolean}>}
+   */
+  evaluateUrl: async (context, org, site, url) => {
+    const {
+      log,
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: lockJson,
+      },
+    } = context;
+    if (!lockJson) {
+      return {
+        allowed: true,
+        reason: 'no lock config',
+      };
+    }
+    try {
+      const lock = JSON.parse(lockJson);
+      const sites = lock[url.hostname];
+      if (!sites) {
+        return {
+          allowed: true,
+          reason: 'no lock info for site',
+        };
+      }
+      for (const project of sites) {
+        const [lockOrg, lockSite] = project.split('/');
+        if (lockOrg === org && (lockSite === '*' || lockSite === site)) {
+          return {
+            allowed: true,
+            reason: 'site allowed by lock',
+          };
+        }
+      }
+      return {
+        allowed: false,
+        reason: `access for ${org}/${site} to ${url.hostname} denied by tenant lock`,
+      };
+    } catch (e) {
+      log.warn(`error evaluating tenant lock for ${org}/${site}`, e);
+      return {
+        allowed: true,
+        reason: 'error evaluating tenant lock',
+      };
+    }
+  },
+
+  /**
+   * Evaluates the source lock configuration and checks if the given site is allowed to use the
+   * respective mountpoint.
+   *
+   * @param {import('./support/AdminContext').AdminContext} context context
+   * @param {string} org org
+   * @param {string} site site
+   * @returns {Promise<{reason: string, allowed: boolean}>}
+   */
+  evaluate: async (context, org, site) => {
+    const { attributes: { config: { content } } } = context;
+    const {
+      log,
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: lockJson,
+      },
+    } = context;
+    if (!lockJson) {
+      return {
+        allowed: true,
+        reason: 'no lock config',
+      };
+    }
+    try {
+      const url = new URL(content.source.url);
+      return sourceLock.evaluateUrl(context, org, site, url);
+    } catch (e) {
+      log.warn(`error evaluating tenant lock for ${org}/${site}`, e);
+      return {
+        allowed: true,
+        reason: 'error evaluating tenant lock',
+      };
+    }
+  },
+
+  /**
+   * Enforces the source lock for the given site.
+   *
+   * @param {import('./support/AdminContext').AdminContext} context context
+   * @param {string} org org
+   * @param {string} site site
+   * @returns {Promise<void>}
+   */
+  assert: async (context, org, site) => {
+    const { log } = context;
+
+    const { allowed, reason } = await sourceLock.evaluate(context, org, site);
+    if (!allowed) {
+      log.error(reason);
+      throw new StatusCodeError('Access denied', 403);
+    }
+  },
+};
+
+export default sourceLock;

--- a/test/support/source-lock.test.js
+++ b/test/support/source-lock.test.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import sourceLock from '../../src/support/source-lock.js';
+import {
+  Nock, SITE_CONFIG, createContext,
+} from '../utils.js';
+
+const SITE_1D_CONFIG = {
+  ...SITE_CONFIG,
+  content: {
+    ...SITE_CONFIG.content,
+    source: {
+      type: 'onedrive',
+      url: 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog',
+    },
+  },
+};
+
+describe('Source Lock Tests', () => {
+  /** @type {import('../utils.js').NockEnv} */
+  let nock;
+
+  beforeEach(() => {
+    nock = new Nock().env();
+  });
+
+  afterEach(() => {
+    nock.done();
+  });
+
+  const suffix = '/owner/sites/repo/status/document';
+
+  it('allows source if env is missing', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix), 'org', 'site'), {
+      allowed: true,
+      reason: 'no lock config',
+    });
+  });
+
+  it('allows source if env is corrupt', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: 'foo',
+      },
+    }), 'org', 'site'), {
+      allowed: true,
+      reason: 'error evaluating tenant lock',
+    });
+  });
+
+  it('allows source if not found in config', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: '{}',
+      },
+    }), 'org', 'site'), {
+      allowed: true,
+      reason: 'no lock info for site',
+    });
+  });
+
+  it('denies source if not found in config', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: JSON.stringify({
+          'adobe.sharepoint.com': [],
+        }),
+      },
+      attributes: { config: SITE_1D_CONFIG },
+    }), 'org', 'site'), {
+      allowed: false,
+      reason: 'access for org/site to adobe.sharepoint.com denied by tenant lock',
+    });
+  });
+
+  it('allows source if found in config', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: JSON.stringify({
+          'adobe.sharepoint.com': ['org/site'],
+        }),
+      },
+      attributes: { config: SITE_1D_CONFIG },
+    }), 'org', 'site'), {
+      allowed: true,
+      reason: 'site allowed by lock',
+    });
+  });
+
+  it('allows source if found in config by org global', async () => {
+    assert.deepStrictEqual(await sourceLock.evaluate(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: JSON.stringify({
+          'adobe.sharepoint.com': ['org/*'],
+        }),
+      },
+      attributes: { config: SITE_1D_CONFIG },
+    }), 'org', 'site'), {
+      allowed: true,
+      reason: 'site allowed by lock',
+    });
+  });
+
+  it('assertSourceLock rejects source if not found in config', async () => {
+    await assert.rejects(sourceLock.assert(createContext(suffix, {
+      env: {
+        HLX_CONTENT_SOURCE_LOCK: JSON.stringify({
+          'adobe.sharepoint.com': [],
+        }),
+      },
+      attributes: { config: SITE_1D_CONFIG },
+    }), 'org', 'site'), new Error('Access denied'));
+  });
+});


### PR DESCRIPTION
and export an object containing the functions, instead of the functions (which would not work for sinon)
