### PR TITLE
fix: add missing await in loadOrgConfig()

### DIFF
--- a/src/config/utils.js
+++ b/src/config/utils.js
@@ -80,7 +80,7 @@ export async function loadSiteConfig(context, org, site) {
 
 export async function loadOrgConfig(context, org) {
   const url = `https://config.aem.page/${org}/config.json?scope=admin`;
-  const orgConfig = loadConfig(context, url, 'org');
+  const orgConfig = await loadConfig(context, url, 'org');
   if (orgConfig) {
     addConfigApiKeys(orgConfig);
   }

--- a/test/contentproxy/utils.js
+++ b/test/contentproxy/utils.js
@@ -39,4 +39,3 @@ export const validMultiSheet = ({
   }))),
   ...overrides,
 });
-


### PR DESCRIPTION
Added tests to cover the path that exposes it both for org and site config.
Also removed a lf at the end of test/contentproxy/utils.js to fix linter issue.