### PR TITLE
fix(discover): reindex all no longer worked

### DIFF
--- a/src/discover/matcher/github.js
+++ b/src/discover/matcher/github.js
@@ -17,11 +17,12 @@ export default class GithubMatcher {
   /**
    * Find the inventory entries that have the given github URL.
    *
+   * @param {import('../support/AdminContext').AdminContext} context context
    * @param {URL} url google document or spreadsheet
    * @param {Inventory} inventory inventory of entries
    */
   // eslint-disable-next-line class-methods-use-this
-  filter(url, inventory) {
+  filter(context, url, inventory) {
     const segs = url.pathname.split('/');
     const [, owner, repo] = segs;
     const codeBusId = `${owner}/${repo}`;

--- a/src/discover/query.js
+++ b/src/discover/query.js
@@ -139,8 +139,8 @@ export default async function query(context) {
     if (!Matcher) {
       return errorResponse(log, 404, `no matcher found for ${url}`);
     }
-    const matcher = new Matcher(context);
-    entries = await matcher.filter(url, inventory);
+    const matcher = new Matcher(context.env);
+    entries = await matcher.filter(context, url, inventory);
   }
 
   const { originalSites, gdriveIds } = lookupHiddenForks(entries);

--- a/src/discover/remove.js
+++ b/src/discover/remove.js
@@ -21,9 +21,9 @@ import { Inventory } from './inventory.js';
  * @param {string} site repo
  * @returns {Promise<Response>} response
  */
-export async function removeProject(ctx, org, site) {
-  const { log } = ctx;
-  const contentBus = HelixStorage.fromContext(ctx).contentBus();
+export async function removeProject(context, org, site) {
+  const { log } = context;
+  const contentBus = HelixStorage.fromContext(context).contentBus();
 
   const inventory = new Inventory(contentBus, log);
   await inventory.load();

--- a/src/live/status.js
+++ b/src/live/status.js
@@ -19,8 +19,8 @@ import getLiveInfo from './info.js';
  * @param {import('../support/RequestInfo').RequestInfo} info request info
  * @returns {Promise<Response>} response
  */
-export default async function liveStatus(ctx, info) {
-  const live = await getLiveInfo(ctx, info);
+export default async function liveStatus(context, info) {
+  const live = await getLiveInfo(context, info);
 
   // return error if not 404
   if (live.status !== 200 && live.status !== 404) {

--- a/test/discover/query.test.js
+++ b/test/discover/query.test.js
@@ -154,6 +154,7 @@ describe('Discover query tests', () => {
       .reply(200, {
         entries: [{
           sharepointSite: 'https://other.sharepoint.com/',
+          codeBusId: 'owner/repo',
         }],
         hostTypes: {
           'other.sharepoint.com': 'sharepoint',
@@ -170,7 +171,8 @@ describe('Discover query tests', () => {
 
     assert.strictEqual(response.status, 200);
     assert.deepStrictEqual(await response.json(), [{
-      githubUrl: 'https://github.com/undefined',
+      codeBusId: 'owner/repo',
+      githubUrl: 'https://github.com/owner/repo',
       originalRepository: false,
       originalSite: false,
     }]);


### PR DESCRIPTION
with our changes to `bucket.list` (shallow), reindexing no longer worked: listing the children of an `org` returned an empty array.
