### PR TITLE
refactor: use StatusCodeError for consistent error handling

### DIFF
--- a/src/source/folder.js
+++ b/src/source/folder.js
@@ -16,6 +16,7 @@ import { createErrorResponse } from '../contentbus/utils.js';
 import { splitExtension } from '../support/RequestInfo.js';
 import { putSourceFile } from './put.js';
 import { getS3Key, CONTENT_TYPES } from './utils.js';
+import { StatusCodeError } from '../support/StatusCodeError.js';
 
 /**
  * A folder is marked by a marker file. This allows folder to show up in bucket
@@ -91,9 +92,7 @@ function validateFolderPath(path) {
   const folder = path.slice(0, -1);
 
   if (!path.endsWith('/') || folder !== sanitizePath(folder)) {
-    const e = new Error('Invalid folder path');
-    e.statusCode = 400;
-    throw e;
+    throw new StatusCodeError('Invalid folder path', 400);
   }
 }
 
@@ -112,7 +111,7 @@ export async function createFolder(context, info) {
     validateFolderPath(path);
     const key = getS3Key(org, site, `${path}${FOLDER_MARKER}`);
 
-    return await putSourceFile(context, key, FOLDER_CONTENT_TYPE, '{}');
+    return await putSourceFile(context, key, 'application/json', '{}');
   } catch (e) {
     const opts = { e, log: context.log };
     opts.status = e.$metadata?.httpStatusCode;

--- a/src/source/put.js
+++ b/src/source/put.js
@@ -13,6 +13,7 @@ import { Response } from '@adobe/fetch';
 import { HelixStorage } from '@adobe/helix-shared-storage';
 import { createErrorResponse } from '../contentbus/utils.js';
 import { getSourceKey, CONTENT_TYPES } from './utils.js';
+import { StatusCodeError } from '../support/StatusCodeError.js';
 
 /**
  * Get the content type from the extension.
@@ -26,9 +27,7 @@ function contentTypeFromExtension(ext) {
   if (contentType) {
     return contentType;
   }
-  const e = new Error(`Unknown file type: ${ext}`);
-  e.$metadata = { httpStatusCode: 415 };
-  throw e;
+  throw new StatusCodeError(`Unknown file type: ${ext}`, 415);
 }
 
 /**

--- a/test/source/folder.test.js
+++ b/test/source/folder.test.js
@@ -80,7 +80,12 @@ describe('Source List Tests', () => {
 
   it('test GET folder', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fa%2Fb%2Fc%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/a/b/c/',
+      })
       .reply(200, Buffer.from(BUCKET_LIST_RESULT1));
 
     const info = createInfo('/org1/sites/site2/source/a/b/c/');
@@ -109,7 +114,12 @@ describe('Source List Tests', () => {
 
   it('test HEAD folder', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fa%2Fb%2Fc%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/a/b/c/',
+      })
       .reply(200, Buffer.from(BUCKET_LIST_RESULT1));
 
     const info = createInfo('/org1/sites/site2/source/a/b/c/');
@@ -120,7 +130,12 @@ describe('Source List Tests', () => {
 
   it('test GET folder with no contents', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fsome%2Fsubfolder%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/some/subfolder/',
+      })
       .reply(200, Buffer.from(BUCKET_LIST_RESULT2));
 
     const info = createInfo('/org1/sites/site2/source/some/subfolder/');
@@ -132,7 +147,12 @@ describe('Source List Tests', () => {
 
   it('test HEAD folder with no contents', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fsome%2Fsubfolder%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/some/subfolder/',
+      })
       .reply(200, Buffer.from(BUCKET_LIST_RESULT2));
 
     const info = createInfo('/org1/sites/site2/source/some/subfolder/');
@@ -143,7 +163,12 @@ describe('Source List Tests', () => {
 
   it('test GET folder does not exist', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fbase%2Fsub%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/base/sub/',
+      })
       .reply(200);
 
     const info = createInfo('/org1/sites/site2/source/base/sub/');
@@ -153,7 +178,12 @@ describe('Source List Tests', () => {
 
   it('test HEAD folder does not exist', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fbase%2Fsub%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/base/sub/',
+      })
       .reply(200);
 
     const info = createInfo('/org1/sites/site2/source/base/sub/');
@@ -163,7 +193,12 @@ describe('Source List Tests', () => {
 
   it('test GET folder with error', async () => {
     nock.source()
-      .get('/?delimiter=%2F&list-type=2&prefix=org1%2Fsite2%2Fa%2Fb%2Fc%2F')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': '2',
+        prefix: 'org1/site2/a/b/c/',
+      })
       .replyWithError('Oh no!');
 
     const info = createInfo('/org1/sites/site2/source/a/b/c/');


### PR DESCRIPTION
## Changes

- Replace manual error creation with StatusCodeError in folder.js and put.js for consistent error handling
- Use 'application/json' content type directly instead of FOLDER_CONTENT_TYPE constant
- Improve test readability by using .query() instead of URL-encoded query strings

## Testing

Tests updated to reflect the changes and maintain coverage.