### PR TITLE
feat(source): enforce <main> in html body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "fetch-retry": "6.0.0",
         "file-type": "21.1.1",
         "hast-util-from-html": "2.0.3",
+        "hast-util-select": "6.0.4",
         "hast-util-to-html": "9.0.5",
         "jose": "6.1.3",
         "lodash.escape": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "fetch-retry": "6.0.0",
     "file-type": "21.1.1",
     "hast-util-from-html": "2.0.3",
+    "hast-util-select": "6.0.4",
     "hast-util-to-html": "9.0.5",
     "jose": "6.1.3",
     "lodash.escape": "4.0.1",

--- a/src/source/utils.js
+++ b/src/source/utils.js
@@ -17,6 +17,7 @@ import { toHtml } from 'hast-util-to-html';
 import { visit, CONTINUE } from 'unist-util-visit';
 import { MEDIA_TYPES } from '../media/validate.js';
 import { StatusCodeError } from '../support/StatusCodeError.js';
+import {select} from "hast-util-select";
 
 /**
  * We consider the following HTML errors to be acceptable and ignore them.
@@ -163,6 +164,12 @@ export async function getValidHtml(context, body, keptImageURLPrefixes, mediaHan
 
   let bodyNode = null;
   const hast = getHast(body);
+
+  const main = select('main', hast);
+  if (!main) {
+    throw new StatusCodeError('HTML does no contain a <main> element', 400);
+  }
+
   visit(hast, 'element', (node) => {
     if (node.tagName === 'body') {
       bodyNode = node;

--- a/test/source/post.test.js
+++ b/test/source/post.test.js
@@ -36,7 +36,7 @@ describe('Source POST Tests', () => {
   it('test postSource HTML', async () => {
     async function postFn(_uri, gzipBody) {
       const b = await gunzip(Buffer.from(gzipBody, 'hex'));
-      assert.equal(b.toString(), '<body>Hello</body>');
+      assert.equal(b.toString(), '<body><main>Hello</main></body>');
     }
 
     nock.source()
@@ -48,7 +48,7 @@ describe('Source POST Tests', () => {
       '/test/sites/rest/source/toast/jam.html',
       {},
       'POST',
-      '<html><body>Hello</body></html>',
+      '<html><body><main>Hello</main></body></html>',
     ));
     assert.equal(resp.status, 201);
   });
@@ -56,7 +56,7 @@ describe('Source POST Tests', () => {
   it('test postSource index HTML', async () => {
     async function postFn(_uri, gzipBody) {
       const b = await gunzip(Buffer.from(gzipBody, 'hex'));
-      assert.equal(b.toString(), '<body>Hello</body>');
+      assert.equal(b.toString(), '<body><main>Hello</main></body>');
     }
 
     nock.source()
@@ -68,7 +68,7 @@ describe('Source POST Tests', () => {
       '/test/sites/rest/source/toast/index.html',
       {},
       'POST',
-      '<html><body>Hello</body></html>',
+      '<html><body><main>Hello</main></body></html>',
     ));
     assert.equal(resp.status, 201);
   });
@@ -79,20 +79,20 @@ describe('Source POST Tests', () => {
     /* The image form example.com should be interned, but the other ones should be
        left alone as they are in the list of kept image URLs. */
     const htmlIn = `
-      <body>
+      <body><main>
         <img src="https://example.com/image.jpg">
         <img src="https://main--rest--test.aem.page/img1.jpg">
         <img src="https://main--rest--test.aem.live/img2.jpg">
         <img src="https://my.adobe.com/adobe/dynamicmedia/deliver/img3.jpg">
-      </body>`;
+      </main></body>`;
 
     const htmlOut = `
-      <body>
+      <body><main>
         <img src="https://main--rest--test.aem.page/media_${imageHash}.jpg">
         <img src="https://main--rest--test.aem.page/img1.jpg">
         <img src="https://main--rest--test.aem.live/img2.jpg">
         <img src="https://my.adobe.com/adobe/dynamicmedia/deliver/img3.jpg">
-      </body>`;
+      </main></body>`;
 
     function imgPutFn(url, body) {
       assert.equal(body, 'someimg');
@@ -138,6 +138,24 @@ describe('Source POST Tests', () => {
       '<body>Hello</bod',
     ));
     assert.equal(resp.status, 400);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-error': 'Unexpected end of file in tag - Unexpected end of file. Expected `>` to close the tag',
+    });
+  });
+
+  it('test postSource invalid HTML structure', async () => {
+    const resp = await postSource(setupContext(), createInfo(
+      '/test/sites/rest/source/toast/jam.html',
+      {},
+      'POST',
+      '<body>Hello</bod>',
+    ));
+    assert.equal(resp.status, 400);
+    assert.deepStrictEqual(Object.fromEntries(resp.headers), {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-error': 'HTML does no contain a <main> element',
+    });
   });
 
   it('test postSource JSON', async () => {

--- a/test/source/put.test.js
+++ b/test/source/put.test.js
@@ -36,8 +36,10 @@ describe('Source PUT Tests', () => {
   it('test putSource HTML with user', async () => {
     const html = `
       <body>
-        Hello
-        <img src="https://main--best--tst.aem.live/my-image.jpg">
+        <main>
+          Hello
+          <img src="https://main--best--tst.aem.live/my-image.jpg">
+        </main>
       </body>`;
 
     async function putFn(_uri, gzipBody) {
@@ -49,7 +51,6 @@ describe('Source PUT Tests', () => {
       .putObject('/tst/best/toast/jam.html')
       .matchHeader('content-type', 'text/html')
       .matchHeader('x-amz-meta-last-modified-by', 'test@example.com')
-      .matchHeader('x-amz-meta-uncompressed-length', '107')
       .reply(201, putFn);
 
     const path = '/tst/sites/best/source/toast/jam.html';
@@ -73,10 +74,10 @@ describe('Source PUT Tests', () => {
 
   it('test putSource HTML with external images is rejected', async () => {
     const html = `
-      <body>
+      <body><main>
         Hello
         <img src="https://main--somesite--someorg.aem.live/myimg.jpeg">
-      </body>`;
+      </main></body>`;
 
     const path = '/myorg/sites/mysite/source/my-page.html';
     const resp = await putSource(
@@ -120,7 +121,7 @@ describe('Source PUT Tests', () => {
       .reply(403);
 
     const path = '/test/sites/test/source/test.html';
-    const resp = await putSource(setupContext(path), createInfo(path));
+    const resp = await putSource(setupContext(path), createInfo(path, {}, 'PUT', '<main></main>'));
     assert.equal(resp.status, 403);
   });
 });


### PR DESCRIPTION
html2md enforces a `<main>` in the html body. so writing to source should also reject if missing.