### PR TITLE
feat: add authInfo as getter to AdminContext

### DIFF
--- a/src/auth/authzn.js
+++ b/src/auth/authzn.js
@@ -18,7 +18,7 @@ import { RoleMapping } from './RoleMapping.js';
  * @param {import('../support/RequestInfo').RequestInfo} info request info
  */
 export async function authorize(context) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
 
   // check if we have any roles or user in the invocation event itself
   if (context?.invocation?.event) {

--- a/src/auth/exchange-token.js
+++ b/src/auth/exchange-token.js
@@ -276,7 +276,7 @@ export async function exchangeToken(context, info, idp, tenantId) {
     .sign(privateKey);
 
   // ensure that auth cookie is not cleared again in `index.js`
-  context.attributes.authInfo?.withCookieInvalid(false);
+  context.authInfo.withCookieInvalid(false);
 
   // if a extensionId is provided, we send the token via sendmessage
   if (extensionId === 'cookie') {

--- a/src/code/handler.js
+++ b/src/code/handler.js
@@ -35,7 +35,7 @@ export default async function codeHandler(context, info) {
     });
   }
 
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
 
   const canonical = checkCanonicalRepo(context, info);
   if (canonical) {

--- a/src/code/info.js
+++ b/src/code/info.js
@@ -14,12 +14,13 @@ import { fetchS3 } from '@adobe/helix-admin-support';
 /**
  * Returns the code bus info for the given resource. If the resource is missing, it will not
  * have a contentType.
- * @param {import('../support/AdminContext').AdminContext} ctx the context
+ * @param {import('../support/AdminContext').AdminContext} context the context
  * @param {import('../support/RequestInfo').RequestInfo} info lookup options
  * @returns {Promise<CodeBusResource>} a resource
  */
-export async function getCodeBusInfo(ctx, info) {
-  if (!ctx.attributes.authInfo.hasPermissions('code:read')) {
+export async function getCodeBusInfo(context, info) {
+  const { authInfo } = context;
+  if (!authInfo.hasPermissions('code:read')) {
     return {
       status: 403,
     };
@@ -27,18 +28,18 @@ export async function getCodeBusInfo(ctx, info) {
   if (!info.rawPath || info.rawPath === '/') {
     return {
       status: 400,
-      permissions: ctx.attributes.authInfo.getPermissions('code:'),
+      permissions: authInfo.getPermissions('code:'),
     };
   }
 
   const ref = info.query.ref || info.ref;
   const branch = info.query.branch || ref;
   const key = `${info.owner}/${info.repo}/${ref}${info.rawPath}`;
-  const resp = await fetchS3(ctx, 'code', key, true);
+  const resp = await fetchS3(context, 'code', key, true);
   const ret = {
     status: resp.status,
-    codeBusId: `${ctx.attributes.bucketMap.code}/${key}`,
-    permissions: ctx.attributes.authInfo.getPermissions('code:'),
+    codeBusId: `${context.attributes.bucketMap.code}/${key}`,
+    permissions: authInfo.getPermissions('code:'),
     // TODO: respect byo git ?
     sourceLocation: `https://raw.githubusercontent.com/${info.owner}/${info.repo}/${branch}${info.rawPath}`,
   };

--- a/src/code/list-branches.js
+++ b/src/code/list-branches.js
@@ -19,7 +19,7 @@ import { HelixStorage } from '@adobe/helix-shared-storage';
  * @returns {Promise<Response>} response
  */
 export async function listBranches(ctx, info) {
-  ctx.attributes.authInfo.assertPermissions('code:read');
+  ctx.authInfo.assertPermissions('code:read');
   const { org, site } = info;
   const codeBus = HelixStorage.fromContext(ctx).codeBus();
   const branches = await codeBus.listFolders(`${org}/${site}/`);

--- a/src/code/status.js
+++ b/src/code/status.js
@@ -20,7 +20,7 @@ import { getCodeBusInfo } from './info.js';
  * @returns {Promise<Response>} response
  */
 export async function status(ctx, info) {
-  ctx.attributes.authInfo.assertPermissions('code:read');
+  ctx.authInfo.assertPermissions('code:read');
   const codeInfo = await getCodeBusInfo(ctx, info);
   if (codeInfo.status === 404) {
     return new Response('', {

--- a/src/code/update.js
+++ b/src/code/update.js
@@ -31,8 +31,7 @@ import { errorResponse } from '../support/utils.js';
  * @param {import('../support/AdminContext').AdminContext} ctx
  */
 function isDeploymentAllowed(ctx) {
-  const { authInfo } = ctx;
-  return authInfo?.hasPermissions('code:write') === true;
+  return ctx.authInfo.hasPermissions('code:write') === true;
 }
 
 /**

--- a/src/code/update.js
+++ b/src/code/update.js
@@ -31,7 +31,7 @@ import { errorResponse } from '../support/utils.js';
  * @param {import('../support/AdminContext').AdminContext} ctx
  */
 function isDeploymentAllowed(ctx) {
-  const { attributes: { authInfo } } = ctx;
+  const { authInfo } = ctx;
   return authInfo?.hasPermissions('code:write') === true;
 }
 

--- a/src/config/AggregatedHandler.js
+++ b/src/config/AggregatedHandler.js
@@ -26,7 +26,7 @@ class AggregatedHandler extends BaseHandler {
 
   // eslint-disable-next-line class-methods-use-this
   async getAggregatedSite(context, org, site) {
-    const { attributes: { authInfo } } = context;
+    const { authInfo } = context;
     const isRedacted = !authInfo.hasPermissions('config:read');
 
     const sitesStore = new AdminConfigStore(org, 'sites', site);

--- a/src/config/BaseHandler.js
+++ b/src/config/BaseHandler.js
@@ -49,7 +49,7 @@ export class BaseHandler {
   }
 
   async handleJSON(context, info, op) {
-    const { attributes: { authInfo }, data } = context;
+    const { authInfo, data } = context;
     const { org } = info;
 
     const { type, name, rest = [] } = this.determineConfigType(info);
@@ -105,7 +105,7 @@ export class BaseHandler {
   }
 
   async handle(context, info) {
-    const { attributes: { authInfo }, log } = context;
+    const { authInfo, log } = context;
     const { method } = info;
 
     const op = OPERATIONS[method];

--- a/src/contentbus/contentbus.js
+++ b/src/contentbus/contentbus.js
@@ -45,14 +45,19 @@ export function getMetadataPaths(context) {
  * @returns {Promise<import('./contentbus.js').ContentBusResource>} a resource
  */
 export async function getContentBusInfo(context, info, partition) {
-  const { attributes } = context;
-  const { content: { contentBusId, source: { type } } } = attributes.config;
+  const {
+    attributes: {
+      bucketMap,
+    }, authInfo, config: {
+      content: { contentBusId, source: { type } },
+    },
+  } = context;
 
   const key = `${contentBusId}/${partition}${info.resourcePath}`;
   const response = await fetchS3(context, 'content', key, true);
   const ret = {
     status: response.status,
-    contentBusId: `${attributes.bucketMap.content}/${key}`,
+    contentBusId: `${bucketMap.content}/${key}`,
   };
   if (response.ok) {
     ret.contentType = response.headers.get('content-type');
@@ -70,7 +75,7 @@ export async function getContentBusInfo(context, info, partition) {
     if (!ret.sourceLocation && type) {
       ret.sourceLocation = `${type}:*`;
     }
-    if (attributes.authInfo?.hasPermissions('log:read')) {
+    if (authInfo.hasPermissions('log:read')) {
       ret.lastModifiedBy = response.headers.get('x-last-modified-by') || undefined;
     }
   } else if (response.status !== 404) {

--- a/src/contentbus/copy.js
+++ b/src/contentbus/copy.js
@@ -21,7 +21,7 @@ import { createErrorResponse } from './utils.js';
  * @returns {Promise<Response>} response
  */
 export default async function copy(context, info) {
-  const { attributes, contentBusId, log } = context;
+  const { authInfo, contentBusId, log } = context;
   const { resourcePath } = info;
 
   try {
@@ -31,7 +31,7 @@ export default async function copy(context, info) {
       `${contentBusId}/live${resourcePath}`,
       {
         addMetadata: {
-          'x-last-modified-by': attributes.authInfo?.resolveEmail() || 'anonymous',
+          'x-last-modified-by': authInfo.resolveEmail() || 'anonymous',
         },
       },
     );

--- a/src/contentbus/update.js
+++ b/src/contentbus/update.js
@@ -96,7 +96,7 @@ export default async function update(context, info) {
         response.headers.set('redirect-location', redirectLocation);
       }
     }
-    response.headers.set('x-last-modified-by', context.attributes?.authInfo?.resolveEmail() || 'anonymous');
+    response.headers.set('x-last-modified-by', context.authInfo?.resolveEmail() || 'anonymous');
     if (!response.headers.has('last-modified')) {
       response.headers.set('last-modified', new Date().toUTCString());
     }

--- a/src/contentbus/update.js
+++ b/src/contentbus/update.js
@@ -96,7 +96,7 @@ export default async function update(context, info) {
         response.headers.set('redirect-location', redirectLocation);
       }
     }
-    response.headers.set('x-last-modified-by', context.authInfo?.resolveEmail() || 'anonymous');
+    response.headers.set('x-last-modified-by', context.authInfo.resolveEmail() || 'anonymous');
     if (!response.headers.has('last-modified')) {
       response.headers.set('last-modified', new Date().toUTCString());
     }

--- a/src/contentproxy/utils.js
+++ b/src/contentproxy/utils.js
@@ -131,7 +131,7 @@ export function assertValidSheetJSON(obj) {
  * @returns {object} provider headers
  */
 export function getContentSourceHeaders(context, info, source) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
   const { headers, rawPath } = info;
   const providerHeaders = {};
 

--- a/src/discover/handler.js
+++ b/src/discover/handler.js
@@ -27,7 +27,7 @@ const ALLOWED_METHODS = ['GET', 'POST', 'DELETE'];
  * @returns {Promise<Response>} response
  */
 export default async function discoverHandler(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {

--- a/src/discover/query.js
+++ b/src/discover/query.js
@@ -135,7 +135,7 @@ export async function viewEntry(context, org, site) {
  * @returns {Promise<Response>} response
  */
 export default async function query(context) {
-  const { attributes: { authInfo }, data: { url: urlString }, log } = context;
+  const { authInfo, data: { url: urlString }, log } = context;
   if (!urlString) {
     const { data: { org, site } } = context;
     if (!(org && site)) {

--- a/src/discover/reindex.js
+++ b/src/discover/reindex.js
@@ -206,7 +206,7 @@ export async function setOriginalSite(context, org, site) {
  * @returns {Promise<Response>} response
  */
 export async function reindex(context) {
-  const { attributes: { authInfo }, data } = context;
+  const { authInfo, data } = context;
   if (data.org === '*') {
     return reindexAll(context);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ async function run(request, context) {
 
   await context.authenticate(info);
 
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
   if (info.org && !authInfo.authenticated) {
     return new Response('', { status: 401 });
   }

--- a/src/index/handler.js
+++ b/src/index/handler.js
@@ -29,7 +29,7 @@ const ALLOWED_METHODS = ['GET', 'POST', 'DELETE'];
  * @returns {Promise<Response>} response
  */
 export default async function indexHandler(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
   const { org, site, webPath } = info;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {

--- a/src/job/Job.js
+++ b/src/job/Job.js
@@ -245,7 +245,7 @@ export class Job {
   static async create(ctx, info, topic, opts = {}) {
     const {
       maxQueued = 1024, data = {}, roles = [],
-      user = ctx.attributes?.authInfo?.resolveEmail(),
+      user = ctx.authInfo.resolveEmail(),
       jobClass = Job, noAudit = false,
     } = opts;
     let { transient } = opts;
@@ -778,7 +778,7 @@ export class Job {
 
       this.state = buf ? JSON.parse(buf.toString('utf-8')) : null;
       if (this.state?.user) {
-        const { authInfo } = this.ctx.attributes;
+        const { authInfo } = this.ctx;
         authInfo.withProfile({
           ...(authInfo.profile ?? {}),
           email: this.state.user,
@@ -795,7 +795,7 @@ export class Job {
    */
   async getStatusResponse(report = '') {
     let body;
-    const state = this.ctx.attributes?.authInfo?.hasPermissions?.('log:read')
+    const state = this.ctx.authInfo.hasPermissions?.('log:read')
       ? this.state
       : { ...this.state, user: undefined };
     if (report === 'details') {

--- a/src/job/handler.js
+++ b/src/job/handler.js
@@ -40,7 +40,7 @@ export const JOB_CLASS = {
  * @returns {Promise<Response>} response
  */
 export default async function jobHandler(ctx, info) {
-  const { log, attributes: { authInfo } } = ctx;
+  const { log, authInfo } = ctx;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {
@@ -85,7 +85,7 @@ export default async function jobHandler(ctx, info) {
 
   // list jobs
   if (info.method === 'GET' && !jobName) {
-    ctx.attributes.authInfo.assertPermissions('job:list');
+    authInfo.assertPermissions('job:list');
     return job.list(ctx, info);
   }
 
@@ -111,7 +111,7 @@ export default async function jobHandler(ctx, info) {
   }
 
   // delete job
-  ctx.attributes.authInfo.assertPermissions('job:write');
+  authInfo.assertPermissions('job:write');
   await job.stop();
   return new Response('', {
     status: 204,

--- a/src/live/handler.js
+++ b/src/live/handler.js
@@ -30,7 +30,7 @@ const ALLOWED_METHODS = ['GET', 'POST', 'DELETE'];
  * @returns {Promise<Response>} response
  */
 export default async function liveHandler(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {

--- a/src/live/info.js
+++ b/src/live/info.js
@@ -20,7 +20,7 @@ import { toResourcePath } from '../support/RequestInfo.js';
  * @returns {Promise<object>} live info
  */
 export default async function getLiveInfo(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (!authInfo.hasPermissions('live:read')) {
     return {

--- a/src/live/unpublish.js
+++ b/src/live/unpublish.js
@@ -26,7 +26,7 @@ import { updateRedirects } from '../redirects/update.js';
  * @returns {Promise<Response>} response
  */
 export default async function unpublish(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
   const { resourcePath } = info;
 
   if (!authInfo.hasPermissions('live:delete-forced')) {

--- a/src/log/add.js
+++ b/src/log/add.js
@@ -22,7 +22,7 @@ import { AuditBatch } from '../support/AuditBatch.js';
  * @returns {Promise<Response>} response
  */
 export default async function add(context, info) {
-  const { attributes: { authInfo }, contentBusId, log } = context;
+  const { authInfo, contentBusId, log } = context;
 
   const { data: { entries } } = context;
   if (!entries || !Array.isArray(entries)) {

--- a/src/log/handler.js
+++ b/src/log/handler.js
@@ -26,7 +26,7 @@ const ALLOWED_METHODS = ['GET', 'POST'];
  * @returns {Promise<Response>} response
  */
 export default async function logHandler(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {

--- a/src/login/handler.js
+++ b/src/login/handler.js
@@ -89,7 +89,7 @@ export async function logout(context, info) {
  * @returns {Promise<Response>} response
  */
 export async function login(context, info) {
-  const { log, attributes: { authInfo }, data } = context;
+  const { log, authInfo, data } = context;
 
   // for login requests with repo coordinates, perform mountpoint specific login
   if (data.org && data.site) {
@@ -184,7 +184,7 @@ export async function login(context, info) {
  */
 export async function auth(context, info) {
   const {
-    log, data, attributes: { authInfo }, suffix,
+    log, data, authInfo, suffix,
   } = context;
 
   if (suffix === '/auth/discovery/keys') {

--- a/src/media/handler.js
+++ b/src/media/handler.js
@@ -94,7 +94,7 @@ async function upload(context, info) {
  * @return {Promise<Response>} response
  */
 export default async function mediaHandler(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {

--- a/src/preview/bulk-preview.js
+++ b/src/preview/bulk-preview.js
@@ -74,7 +74,7 @@ export default async function bulkPreview(context, info) {
 
   if (hasSubtreePath || paths.length > 100) {
     // only assert list permissions when there's a deep path
-    context.attributes.authInfo.assertPermissions('edit:list');
+    context.authInfo.assertPermissions('edit:list');
   }
 
   if (paths.length > MAX_SYNC_PATHS[handler.name] && String(context.data.forceAsync) !== 'true') {

--- a/src/preview/handler.js
+++ b/src/preview/handler.js
@@ -30,7 +30,7 @@ const ALLOWED_METHODS = ['GET', 'POST', 'DELETE'];
  * @returns {Promise<Response>} response
  */
 export default async function previewHandler(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
 
   if (ALLOWED_METHODS.indexOf(info.method) < 0) {
     return new Response('method not allowed', {

--- a/src/preview/info.js
+++ b/src/preview/info.js
@@ -20,7 +20,7 @@ import { toResourcePath } from '../support/RequestInfo.js';
  * @returns {Promise<object>} live info
  */
 export default async function getPreviewInfo(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (!authInfo.hasPermissions('preview:read')) {
     return {

--- a/src/preview/unpreview.js
+++ b/src/preview/unpreview.js
@@ -24,7 +24,7 @@ import { updateRedirects } from '../redirects/update.js';
  * @returns {Promise<Response>} response
  */
 export default async function unpreview(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
   const { resourcePath } = info;
 
   if (!authInfo.hasPermissions('preview:delete-forced')) {

--- a/src/profile/handler.js
+++ b/src/profile/handler.js
@@ -32,7 +32,7 @@ export default async function profileHandler(context, info) {
   }
 
   // send 401 if not authenticated
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
   const { profile } = authInfo;
   if (!profile) {
     const data = {

--- a/src/sidekick/csrf.js
+++ b/src/sidekick/csrf.js
@@ -136,7 +136,7 @@ export async function sidekickCSRFProtection(context, info) {
   }
 
   const { headers = {} } = info;
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
 
   if (!authInfo || !authInfo.authenticated || !authInfo.extensionId) {
     // CSRF only applies to authenticated requests

--- a/src/sidekick/handler.js
+++ b/src/sidekick/handler.js
@@ -20,7 +20,7 @@ import { getConfigJsonResponse } from './utils.js';
  * @returns {Promise<Response>} response
  */
 export default async function sidekickHandler(context, info) {
-  const { attributes: { authInfo } } = context;
+  const { authInfo } = context;
 
   if (info.method !== 'GET') {
     return new Response('method not allowed', {

--- a/src/source/utils.js
+++ b/src/source/utils.js
@@ -410,9 +410,7 @@ export async function accessSourceFile(context, key, headRequest) {
  * @return {string} user or 'anonymous'
  */
 export function getUser(context) {
-  const email = context.attributes.authInfo?.profile?.email;
-
-  return email || 'anonymous';
+  return context.authInfo.profile?.email || 'anonymous';
 }
 
 /**

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -28,7 +28,7 @@ import { getCodeBusInfo } from '../code/info.js';
  * @returns {Promise<Response>} response
  */
 export default async function status(context, info) {
-  const { log, attributes: { authInfo } } = context;
+  const { log, authInfo } = context;
   const { editUrl } = context.data;
 
   if (editUrl && editUrl !== 'auto' && info.webPath !== '/') {

--- a/src/support/AdminContext.js
+++ b/src/support/AdminContext.js
@@ -285,6 +285,14 @@ export class AdminContext {
   }
 
   /**
+   * Returns the authentication info for the current request.
+   * @returns {AuthInfo}
+   */
+  get authInfo() {
+    return this.attributes.authInfo;
+  }
+
+  /**
    * Retrieves the index configuration from the underlying storage and stores
    * it in the context as `indexConfig`.
    *

--- a/src/support/AuditBatch.js
+++ b/src/support/AuditBatch.js
@@ -116,7 +116,7 @@ async function createNotification(context, info, opts) {
     }
   }
 
-  const user = context.attributes?.authInfo?.resolveEmail();
+  const user = context.authInfo.resolveEmail();
   if (user) {
     notification.user = user;
   }

--- a/src/wrappers/catch-all.js
+++ b/src/wrappers/catch-all.js
@@ -26,7 +26,7 @@ export default function catchAll(func) {
       const response = await func(request, context);
       return response;
     } catch (e) {
-      const { log, attributes: { authInfo } } = context;
+      const { log, authInfo } = context;
       /* c8 ignore start */
       if (e instanceof AccessDeniedError) {
         if (authInfo.authenticated) {

--- a/test/code/list-branches.test.js
+++ b/test/code/list-branches.test.js
@@ -64,11 +64,11 @@ describe('Code List Branches Tests', () => {
   });
 
   it('list branches needs code:read permissions', async () => {
-    await assert.rejects(listBranches({
-      log: console,
+    const context = createContext('/', {
       attributes: {
-        authInfo: new AuthInfo(),
+        authInfo: AuthInfo.Default(),
       },
-    }, {}), new AccessDeniedError('code:read'));
+    });
+    await assert.rejects(listBranches(context, {}), new AccessDeniedError('code:read'));
   });
 });

--- a/test/code/status.test.js
+++ b/test/code/status.test.js
@@ -58,12 +58,12 @@ describe('Code Status Tests', () => {
   });
 
   it('code status needs code:read permission', async () => {
-    await assert.rejects(status({
-      log: console,
+    const context = createContext('/', {
       attributes: {
-        authInfo: new AuthInfo(),
+        authInfo: AuthInfo.Default().withAuthenticated(true),
       },
-    }, {}), new AccessDeniedError('code:read'));
+    });
+    await assert.rejects(status(context, {}), new AccessDeniedError('code:read'));
   });
 
   it('code status throws error for underlying error', async () => {

--- a/test/live/info.test.js
+++ b/test/live/info.test.js
@@ -16,7 +16,9 @@ import { Request } from '@adobe/fetch';
 import { AuthInfo } from '../../src/auth/AuthInfo.js';
 import getLiveInfo from '../../src/live/info.js';
 import { main } from '../../src/index.js';
-import { createInfo, Nock, SITE_CONFIG } from '../utils.js';
+import {
+  createContext, createInfo, Nock, SITE_CONFIG,
+} from '../utils.js';
 
 describe('Live Info Tests', () => {
   /** @type {import('../utils.js').NockEnv} */
@@ -94,13 +96,13 @@ describe('Live Info Tests', () => {
 describe('getLiveInfo unit tests', () => {
   it('returns 403 when live:read permission is missing', async () => {
     const info = createInfo('/org/sites/site/live/document');
-    const ctx = {
+    const context = createContext('/org/sites/site/live/document', {
       attributes: {
         authInfo: AuthInfo.Default(),
         config: structuredClone(SITE_CONFIG),
       },
-    };
-    const result = await getLiveInfo(ctx, info);
+    });
+    const result = await getLiveInfo(context, info);
     assert.strictEqual(result.status, 403);
     assert.strictEqual(result.error, 'forbidden');
   });


### PR DESCRIPTION
This PR introduces a dedicated `authInfo` getter on `AdminContext` and updates call sites to consume `authInfo` via `context`/`ctx` destructuring rather than `attributes.authInfo`.

- `src/support/AdminContext.js`
  - Added:
    - `get authInfo() { return this.attributes.authInfo; }`

